### PR TITLE
Update scanner color without restarts

### DIFF
--- a/Config.cs
+++ b/Config.cs
@@ -32,6 +32,11 @@ namespace ScanRecolor
             Green   = ScanRecolor.Plugin.BepInExConfig().Bind("Color", "Green", 255,    new ConfigDescription("Green scan color.", new AcceptableValueRange<int>(0, 255)));
             Blue    = ScanRecolor.Plugin.BepInExConfig().Bind("Color", "Blue", 0,       new ConfigDescription("Blue scan color.", new AcceptableValueRange<int>(0, 255)));
             Alpha   = ScanRecolor.Plugin.BepInExConfig().Bind("Color", "Alpha", 0.45f,  new ConfigDescription("Alpha / opaticty.", new AcceptableValueRange<float>(0f, 1f)));
+
+            Red.SettingChanged += (obj, args) => { HUDManagerPatch.SetScanColor(); };
+            Green.SettingChanged += (obj, args) => { HUDManagerPatch.SetScanColor(); };
+            Blue.SettingChanged += (obj, args) => { HUDManagerPatch.SetScanColor(); };
+            Alpha.SettingChanged += (obj, args) => { HUDManagerPatch.SetScanColor(); };
         }
     }
 }

--- a/HUDManagerPatch.cs
+++ b/HUDManagerPatch.cs
@@ -6,14 +6,19 @@ namespace ScanRecolor
     [HarmonyPatch]
     internal class HUDManagerPatch
     {
-        [HarmonyPatch(typeof(HUDManager), "Start")]
-        [HarmonyPostfix]
-        public static void HUDManagerStartPostfix()
+        public static void SetScanColor()
         {
             var scanMaterial = HUDManager.Instance.scanEffectAnimator.GetComponent<MeshRenderer>()?.material;
             if (scanMaterial == null) return;
 
             scanMaterial.color = new Color(1f / Config.Instance.Red.Value, 1f / Config.Instance.Green.Value, 1f / Config.Instance.Blue.Value, Config.Instance.Alpha.Value);
+        }
+
+        [HarmonyPatch(typeof(HUDManager), "Start")]
+        [HarmonyPostfix]
+        public static void HUDManagerStartPostfix()
+        {
+            SetScanColor();
         }
     }
 }


### PR DESCRIPTION
This allows players to change the color values in the config and have them apply without having to restart their game or lobby

https://github.com/user-attachments/assets/8cdf5b42-e887-463a-88f4-82c58af47c8e

